### PR TITLE
解决cookie_to_dict可能执行失败的问题

### DIFF
--- a/dailynotehelper/getinfo/utils.py
+++ b/dailynotehelper/getinfo/utils.py
@@ -127,5 +127,10 @@ def request(*args, **kwargs):
 
 def cookie_to_dict(cookie) -> dict:
     if cookie and '=' in cookie:
-        cookie = dict([line.strip().split('=', 1) for line in cookie.split(';')])
+        lines = [line.strip().split('=') for line in cookie.split(';')]
+        cookie = {}
+        for item in lines:
+            if not item[0]:
+                continue
+            cookie.setdefault(item[0], item[1])
     return cookie


### PR DESCRIPTION
原来的方式会报错
Python 3.10.5
```
ValueError: dictionary update sequence element #4 has length 1; 2 is required
```